### PR TITLE
Add some things from C/C++ to Zig.gitignore

### DIFF
--- a/Zig.gitignore
+++ b/Zig.gitignore
@@ -2,3 +2,31 @@
 
 zig-cache/
 zig-out/
+build/
+build-*/
+docgen_tmp/
+
+# Compiled Object files
+*.slo
+*.lo
+*.o
+*.obj
+*.elf
+*.ko
+
+# Compiled Dynamic libraries
+*.so
+*.dylib
+*.dll
+
+# Libraries
+*.lib
+*.a
+*.la
+*.lo
+
+# Shared objects (inc. Windows DLLs)
+*.dll
+*.so
+*.so.*
+*.dylib

--- a/Zig.gitignore
+++ b/Zig.gitignore
@@ -1,6 +1,6 @@
 # This file is for zig-specific build artifacts.
 
-zig-cache/
+.zig-cache/
 zig-out/
 build/
 build-*/


### PR DESCRIPTION
For excluding more artifact from Zig compilation, and also C/C++ compilation.